### PR TITLE
Svlint v0.9.0

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Login GitHub Registry
       run: docker login docker.pkg.github.com -u owner -p ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -1,23 +1,25 @@
 name: Regression
-
+# NOT FOR MERGE
 on: [push]
-
+# NOT FOR MERGE
 jobs:
   build:
     runs-on: ubuntu-latest
-
+# NOT FOR MERGE
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    - name: Test with files @ release
-      uses: dalance/svlint-action@v1
+# NOT FOR MERGE
+    - name: Test with files @ regression
+      uses: DaveMcEwan/svlint-action@regression
       with:
         files: |
           test/test1.sv
           test/test2.sv
       continue-on-error: true
-    - name: Test with filelists @ release
-      uses: dalance/svlint-action@v1
+# NOT FOR MERGE
+    - name: Test with filelists @ regression
+      uses: DaveMcEwan/svlint-action@regression
       with:
         filelists: |
           test/test3.f
@@ -25,19 +27,4 @@ jobs:
       continue-on-error: true
       env:
         TEST_DIR: test
-    - name: Test with files @ master
-      uses: dalance/svlint-action@master
-      with:
-        files: |
-          test/test1.sv
-          test/test2.sv
-      continue-on-error: true
-    - name: Test with filelists @ master
-      uses: dalance/svlint-action@master
-      with:
-        filelists: |
-          test/test3.f
-          test/test4.f
-      continue-on-error: true
-      env:
-        TEST_DIR: test
+# NOT FOR MERGE

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -8,7 +8,7 @@ jobs:
 # NOT FOR MERGE
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 # NOT FOR MERGE
     - name: Test with files @ regression
       uses: DaveMcEwan/svlint-action@regression

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -28,3 +28,12 @@ jobs:
       env:
         TEST_DIR: test
 # NOT FOR MERGE
+    - name: Test with ruleset @ svlint-v0.9.0
+      uses: DaveMcEwan/svlint-action@svlint-v0.9.0
+      with:
+        ruleset: parseonly
+        files: |
+          test/test1.sv
+          test/test2.sv
+      continue-on-error: true
+# NOT FOR MERGE

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -10,16 +10,16 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 # NOT FOR MERGE
-    - name: Test with files @ regression
-      uses: DaveMcEwan/svlint-action@regression
+    - name: Test with files @ svlint-v0.9.0
+      uses: DaveMcEwan/svlint-action@svlint-v0.9.0
       with:
         files: |
           test/test1.sv
           test/test2.sv
       continue-on-error: true
 # NOT FOR MERGE
-    - name: Test with filelists @ regression
-      uses: DaveMcEwan/svlint-action@regression
+    - name: Test with filelists @ svlint-v0.9.0
+      uses: DaveMcEwan/svlint-action@svlint-v0.9.0
       with:
         filelists: |
           test/test3.f

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -1,25 +1,23 @@
 name: Regression
-# NOT FOR MERGE
+
 on: [push]
-# NOT FOR MERGE
+
 jobs:
   build:
     runs-on: ubuntu-latest
-# NOT FOR MERGE
+
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-# NOT FOR MERGE
-    - name: Test with files @ svlint-v0.9.0
-      uses: DaveMcEwan/svlint-action@svlint-v0.9.0
+    - name: Test with files @ release
+      uses: dalance/svlint-action@v1
       with:
         files: |
           test/test1.sv
           test/test2.sv
       continue-on-error: true
-# NOT FOR MERGE
-    - name: Test with filelists @ svlint-v0.9.0
-      uses: DaveMcEwan/svlint-action@svlint-v0.9.0
+    - name: Test with filelists @ release
+      uses: dalance/svlint-action@v1
       with:
         filelists: |
           test/test3.f
@@ -27,13 +25,37 @@ jobs:
       continue-on-error: true
       env:
         TEST_DIR: test
-# NOT FOR MERGE
-    - name: Test with ruleset @ svlint-v0.9.0
-      uses: DaveMcEwan/svlint-action@svlint-v0.9.0
+    # TODO: Ruleset test can be enabled after a new release.
+    #- name: Test with ruleset @ release
+    #  uses: dalance/svlint-action@v1
+    #  with:
+    #    ruleset: parseonly
+    #    files: |
+    #      test/test1.sv
+    #      test/test2.sv
+    #  continue-on-error: true
+    - name: Test with files @ master
+      uses: dalance/svlint-action@master
       with:
-        ruleset: parseonly
         files: |
           test/test1.sv
           test/test2.sv
       continue-on-error: true
-# NOT FOR MERGE
+    - name: Test with filelists @ master
+      uses: dalance/svlint-action@master
+      with:
+        filelists: |
+          test/test3.f
+          test/test4.f
+      continue-on-error: true
+      env:
+        TEST_DIR: test
+    # TODO: Ruleset test can be enabled after PR merge.
+    #- name: Test with ruleset @ master
+    #  uses: dalance/svlint-action@master
+    #  with:
+    #    ruleset: parseonly
+    #    files: |
+    #      test/test1.sv
+    #      test/test2.sv
+    #  continue-on-error: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM alpine:3.18
 
 ARG version="v0.6.1"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM alpine:3.18
 
-ARG version="v0.6.1"
+ARG version="v0.9.0"
 
 RUN wget https://github.com/dalance/svlint/releases/download/$version/svlint-$version-x86_64-lnx.zip \
     && unzip svlint-$version-x86_64-lnx.zip \
-    && mv svlint /bin/ \
+    && mv ./bin/* /bin/ \
     && rm svlint-$version-x86_64-lnx.zip
 
 COPY entrypoint.sh /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -1,34 +1,45 @@
-# svlint-action
 
-This action checks SystemVerilog source code by [svlint](https://github.com/dalance/svlint).
+# svlint-action
+This action checks SystemVerilog source code using
+[svlint](https://github.com/dalance/svlint).
+
 
 ## Inputs
+Using svlint on the command line, the list of files to check can be given in
+one of two ways:
+1. Directly, with a list or
+  [glob](https://en.wikipedia.org/wiki/Glob_(programming)) of file paths.
+  For example, `svlint foo.sv bar.sv`
+2. Indirectly, with filelists.
+  For example, `svlint -f foo.f -f bar.f`
+
+Svlint cannot use both filelists and a list of files at the same time.
+Similarly, this action cannot use both `files` and `filelists` inputs at the
+same time.
+
 
 ### `files`
+Paths to SystemVerilog source files.
+NOTE: `files` and `filelists` are mutually exclusive.
 
-The filenames of SystemVerilog source code.
-`files` and `filelists` are exclusive.
-
-### `filelists`
-
-The filenames of filelist.
-`files` and `filelists` are exclusive.
-
-Filelists can include environment variables.
-Environment variables can be passed through `env`.
-
-## Example usage
-
+#### Example Usage
 ```yaml
-uses: dalance/svlint-action@v1
+uses: dalance/svlint-action@master
 with:
   files: |
     src1.sv
     src2.sv
 ```
 
+
+### `filelists`
+The filenames of filelist.
+NOTE: `files` and `filelists` are mutually exclusive.
+Filelists can include environment variables which are can be given via `env`.
+
+#### Example Usage
 ```yaml
-uses: dalance/svlint-action@v1
+uses: dalance/svlint-action@master
 with:
   filelists: |
     list1.f
@@ -36,3 +47,50 @@ with:
 env:
   DIR: test
 ```
+
+
+## TOML Configuration
+By default, svlint will search upwards in the filesystem for a file called
+`.svlint.toml` and if such a file exists, then it is used as the configuration.
+This is ideal for projects which only use one set of rules, as it only requires
+placing your `.svlint.toml` in the root of your repository.
+
+For larger projects which use multiple configurations, perhaps one for design
+and one for verification, the [TOML](https://toml.io/en/) configuration file
+can be specified using the `SVLINT_CONFIG` environment variable:
+```yaml
+uses: dalance/svlint-action@master
+with:
+  files: |
+    src/design/foo.sv
+    src/design/bar.sv
+env:
+  SVLINT_CONFIG: src/design.svlint.toml
+```
+
+If no configuration file is found, all rules are enabled.
+This is almost certain to fail - intentionally, to force users to choose some
+configuration.
+
+
+## Versions of This GitHub Action
+To use this action in your repository, your [YAML](https://yaml.org/) workflow
+file needs a line like `uses: dalance/svlint-action@master`.
+GitHub provides documentation on how to use workflows
+[here](https://docs.github.com/en/actions/using-workflows).
+The
+[`uses`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_iduses)
+line has the format `<GitHubUserName>/<GitHubRepoName>@<GitRef>`.
+That `GitRef` field may be a tag, branch, commit hash, or (most commonly) the
+[MAJOR](https://semver.org/) component of a tag.
+Thus, you can use this action in different ways, according to your needs.
+
+- Use the latest release: `uses: dalance@svlint-action@latest`.
+- Use a specific major release: `uses: dalance@svlint-action@v1`.
+- Use the master branch: `uses: dalance@svlint-action@master`.
+- Use a specific commit: `uses: dalance@svlint-action@6a447be`.
+- Use your own fork: `uses: JohnDoe@svlint-action@master`.
+
+Note: Releases of this action are not necessarily in step with releases of
+svlint.
+

--- a/README.md
+++ b/README.md
@@ -49,15 +49,46 @@ env:
 ```
 
 
-## TOML Configuration
-By default, svlint will search upwards in the filesystem for a file called
-`.svlint.toml` and if such a file exists, then it is used as the configuration.
-This is ideal for projects which only use one set of rules, as it only requires
-placing your `.svlint.toml` in the root of your repository.
+### `ruleset`
+Name of a pre-written ruleset, i.e. a wrapper script which uses a bundled TOML
+configuration.
+NOTE: If a `ruleset` is specified, the environment variable `SVLINT_CONFIG`
+will be ignored.
 
-For larger projects which use multiple configurations, perhaps one for design
-and one for verification, the [TOML](https://toml.io/en/) configuration file
-can be specified using the `SVLINT_CONFIG` environment variable:
+As of svlint v0.9.0, the list of bundled rulesets is:
+- parseonly
+- style
+- simsynth
+- designintent
+- verifintent
+- DaveMcEwan-design
+- DaveMcEwan-designnaming
+
+See the svlint [MANUAL](https://github.com/dalance/svlint/blob/master/MANUAL.md)
+for more details about rulesets (also available as a PDF in a
+[released ZIP](https://github.com/dalance/svlint/releases/download/v0.9.0/svlint-v0.9.0-x86_64-lnx.zip)).
+
+#### Example Usage
+```yaml
+uses: dalance/svlint-action@master
+with:
+  ruleset: parseonly
+  files: |
+    src1.sv
+    src2.sv
+```
+
+
+## TOML Configuration
+When no ruleset is specified, svlint will search upwards in the filesystem for
+a file called `.svlint.toml` and if such a file exists, then it is used as the
+configuration.
+This is ideal for projects which only use one custom set of rules, as it only
+requires placing your `.svlint.toml` in the root of your repository.
+
+For larger projects which use multiple custom configurations, perhaps one for
+design and one for verification, the [TOML](https://toml.io/en/) configuration
+file can be specified using the `SVLINT_CONFIG` environment variable:
 ```yaml
 uses: dalance/svlint-action@master
 with:

--- a/action.yml
+++ b/action.yml
@@ -8,12 +8,16 @@ inputs:
   filelists:
     description: 'Paths to filelist files.'
     required: false
+  ruleset:
+    description: 'Name of a ruleset, e.g "parseonly", "simsynth", etc.'
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
     - ${{ inputs.files }}
     - ${{ inputs.filelists }}
+    - ${{ inputs.ruleset }}
 branding:
   icon: 'check-circle'
   color: 'orange'

--- a/action.yml
+++ b/action.yml
@@ -3,10 +3,10 @@ author: 'dalance'
 description: 'SystemVerilog source code check by svlint'
 inputs:
   files:
-    description: 'filenames of SystemVerilog source code'
+    description: 'Paths to SystemVerilog source files.'
     required: false
   filelists:
-    description: 'filenames of filelist'
+    description: 'Paths to filelist files.'
     required: false
 runs:
   using: 'docker'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,12 +1,21 @@
 #!/bin/sh -l
 
-files=$1
-
 svlint --version
+printf 'SVLINT_CONFIG=%s\n' ${SVLINT_CONFIG}
+
+files=$1
 
 for filelist in $2
 do
     filelists="$filelists -f $filelist"
 done
 
-svlint --github-actions $files $filelists
+ruleset=$3
+if [ -z "$3" ]
+then
+  svlint="svlint"
+else
+  svlint="svlint-$ruleset"
+fi
+
+$svlint --github-actions $files $filelists


### PR DESCRIPTION
- Update svlint to v0.9.0
- Update docker base image to Alpine 3.18
- Add support for a `ruleset` input.
- Extend the README.

There are commented lines in `.github/workflows/regression.yml` which cannot be enabled in this PR, because they depend on this PR being merged and a release made.
I have tested these in my own branch, see <https://github.com/dalance/svlint-action/commit/60a7b51aa29670c55c85a8ef65d0a5d7475f60f9>, so it should be a simple case of uncommenting them.